### PR TITLE
fix: dev: Make regular for prompt more specific

### DIFF
--- a/lib/topology_docker/nodes/openswitch.py
+++ b/lib/topology_docker/nodes/openswitch.py
@@ -224,7 +224,7 @@ class OpenSwitchNode(DockerNode):
 
         # Add vtysh (default) and bash shell
         self._shells['vtysh'] = DockerShell(
-            self.container_id, 'vtysh', 'switch[a-zA-Z0-9\s\_\-\(\)]*#'
+            self.container_id, 'vtysh', '(^|\n)switch(\([\-a-zA-Z0-9]*\))?#'
         )
         self._shells['bash'] = DockerShell(
             self.container_id, 'sh -c "TERM=dumb bash"', 'bash-.*#'


### PR DESCRIPTION
Regular is more specific and takes into consideration when prompt is at the beginning or in a new line.