### PR TITLE
fix: dev: Add bonding_masters to ip link set exceptions

### DIFF
--- a/lib/topology_docker/nodes/openswitch.py
+++ b/lib/topology_docker/nodes/openswitch.py
@@ -87,7 +87,7 @@ def create_interfaces():
 
     # Map the port with the labels
     for portlbl in not_in_swns:
-        if portlbl in ['lo', 'oobm']:
+        if portlbl in ['lo', 'oobm', 'bonding_masters']:
             continue
         hwport = hwports.pop(0)
         mapping_ports[portlbl] = hwport


### PR DESCRIPTION
This change is needed in order to use the Linux bonding driver, otherwise
the tests will fail while setting up the ports.

Signed-off-by: Agustin Meneses <agustin-jose.meneses-fuentes@hpe.com>