### PR TITLE
chg: dev: Add functionality to move logs from containers

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,11 +44,7 @@ Nodes
             'openswitch = topology_docker.nodes.openswitch:OpenSwitchNode'
         ]
     }
-:image: Docker image to use for this node. You can run ``docker images`` to
-        find the images that are available in your docker installation. To
-        specify an image in this attribute, make sure to add the value for the
-        ``REPOSITORY`` column and the value for the ``TAG`` column separated by
-        a colon, like this: ``image="ubuntu:latest"``.
+:image: Docker image to use for this node.
 
 Ports
 -----

--- a/lib/topology_docker/node.py
+++ b/lib/topology_docker/node.py
@@ -32,7 +32,6 @@ from docker import Client
 from six import add_metaclass
 
 from topology.platforms.base import CommonNode
-from topology_docker.utils import ensure_dir
 
 
 log = getLogger(__name__)
@@ -42,11 +41,6 @@ log = getLogger(__name__)
 class DockerNode(CommonNode):
     """
     An instance of this class will create a detached Docker container.
-
-    This node binds the ``/tmp/`` directory of the container to a local path
-    in the host system under ``/tmp/topology_{identifier}_{uuid}/``. This value
-    is stored under ``node.shared_dir`` attribute and can be used to share
-    files.
 
     :param str identifier: The unique identifier of the node.
     :param str image: The image to run on this node, in the
@@ -81,26 +75,16 @@ class DockerNode(CommonNode):
         # Autopull docker image if necessary
         self._autopull()
 
-        # Create shared directory
-        self.shared_dir = '/tmp/topology/{}_{}'.format(
-            identifier, str(id(self))
-        )
-        ensure_dir(self.shared_dir)
-
-        # Add binded directories
-        container_binds = [
-            '{}:/tmp'.format(self.shared_dir)
-        ]
-        if binds is not None:
-            container_binds.extend(binds.split(';'))
-
         # Create host config
+        if binds is not None:
+            binds = binds.split(';')
+
         self._host_config = self._client.create_host_config(
             # Container is given access to all devices
             privileged=True,
             # Avoid connecting to host bridge, usually docker0
             network_mode=network_mode,
-            binds=container_binds
+            binds=binds
         )
 
         # Create container
@@ -193,27 +177,6 @@ class DockerNode(CommonNode):
         Get notified that the post build stage of the topology build was
         reached.
         """
-        # Log container data
-        image_data = self._client.inspect_image(
-            image=self._image
-        )
-        log.info(
-            'Starting container {}:\n'
-            '    Image name: {}\n'
-            '    Image id: {}\n'
-            '    Image creation date: {}'
-            '    Image tags: {}'.format(
-                self.container_id,
-                self._image,
-                image_data.get('Id', '????'),
-                image_data.get('Created', '????'),
-                ', '.join(image_data.get('RepoTags', []))
-            )
-        )
-        container_data = self._client.inspect_container(
-            container=self.container_id
-        )
-        log.debug(container_data)
 
     def start(self):
         """

--- a/lib/topology_docker/platform.py
+++ b/lib/topology_docker/platform.py
@@ -120,7 +120,13 @@ class DockerPlatform(BasePlatform):
         """
         node_a, port_a = nodeport_a
         node_b, port_b = nodeport_b
-
+        
+        node_type_a = node_a.metadata.get('type', 'host')
+        node_type_b = node_b.metadata.get('type', 'host')
+        if node_type_a == 'oobmhost' or node_type_b == 'oobmhost':
+            self.nmlbiport_iface_map[port_a.identifier]['created'] = True
+            self.nmlbiport_iface_map[port_b.identifier]['created'] = True
+            return
         # Get enodes
         enode_a = self.nmlnode_node_map[node_a.identifier]
         enode_b = self.nmlnode_node_map[node_b.identifier]

--- a/lib/topology_docker/plugin/__init__.py
+++ b/lib/topology_docker/plugin/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+topology module entry point.
+"""
+
+from __future__ import unicode_literals, absolute_import
+from __future__ import print_function, division
+
+__author__ = 'Hewlett Packard Enterprise Development LP'
+__email__ = 'hpe-networking@lists.hp.com'
+__version__ = '1.7.1'

--- a/lib/topology_docker/plugin/plugin.py
+++ b/lib/topology_docker/plugin/plugin.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from os.path import exists
+from os import makedirs
+from shutil import copytree, Error, copy
+
+
+def pytest_runtest_teardown(item):
+    """
+    pytest hook to move log files to appropriate test folder
+    """
+    logs_path = '/var/log/messages'
+    if 'topology' in item.funcargs:
+        if 'docker' in item.funcargs['topology'].engine:
+            dirs = []
+            for node in iter(item.funcargs['topology'].nodes):
+                if hasattr(item.funcargs['topology'].get(node), 'shared_dir'):
+                    node_obj = item.funcargs['topology'].get(node)
+                    dirs.append(node_obj.shared_dir)
+                    log_temp_dir = '/tmp/var_messages.log'.format(id(node_obj))
+                    node_obj.send_command('cat {} > {}'
+                                          .format(logs_path, log_temp_dir),
+                                          shell='bash')
+            if dirs:
+                path_name = '/tmp/{}_{}'.format(item.name, str(id(item)))
+                if not exists(path_name):
+                    makedirs(path_name)
+                for directory in dirs:
+                    temp_dir = directory.replace('/tmp/', '')
+                    try:
+                        copytree(directory, '{}/{}'.format(path_name,
+                                                           temp_dir))
+                    except Error as err:
+                        errors = err.args[0]
+                        for error in errors:
+                            src, dest, msg = error
+                            print('Unable to copy file {}, Error {}'
+                                  .format(src, msg))

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,21 +1,11 @@
-# Debugging
-ipdb
-
-# Coding standard
 flake8
 pep8-naming
-
-# Pytest framework
 pytest===2.8.4
 pytest-cov
-pytest-logging
-
-# Documentation
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-plantuml
 autoapi
-
-# Topology libraries
+ipdb
 topology_lib_ip
 topology_lib_ping


### PR DESCRIPTION
pytest plugin functionality implemented, additionally /var/log/messages from openswitch containers will be copied to /tmp/ folder inside the container. I need to add the documentation for this change