### PR TITLE
chg: dev: Updating to topology 1.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Docker Platform Engine for Topology
 ===================================
 
-Docker based Platform Engine plugin for the Network Topology Framework.
+Docker based Platform Engine plugin for the Topology Modular Framework.
 
 
 Documentation

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,7 +12,7 @@ Docker Platform Engine for Topology
 
    .. image:: _static/images/logo.png
 
-Docker based Platform Engine plugin for the Network Topology Framework.
+Docker based Platform Engine plugin for the Topology Modular Framework.
 
 
 Documentation

--- a/lib/topology_docker/node.py
+++ b/lib/topology_docker/node.py
@@ -34,7 +34,7 @@ from abc import ABCMeta, abstractmethod
 from docker import Client
 from six import add_metaclass
 
-from topology.platforms.base import CommonNode
+from topology.platforms.node import CommonNode
 from topology_docker.utils import ensure_dir
 
 

--- a/lib/topology_docker/node.py
+++ b/lib/topology_docker/node.py
@@ -256,6 +256,39 @@ class DockerNode(CommonNode):
                 )
             )
 
+    def _docker_exec(self, command):
+        """
+        Execute a command inside the docker.
+
+        :param str command: The command to execute.
+        """
+        log.debug(
+            '[{}]._docker_exec(\'{}\') ::'.format(self._container_id, command)
+        )
+
+        response = check_output(shsplit(
+            'docker exec {container_id} {command}'.format(
+                container_id=self._container_id, command=command.strip()
+            )
+        )).decode('utf8')
+
+        log.debug(response)
+        return response
+
+    def _get_services_address(self):
+        """
+        Get the service address of the node using Docker's inspect mechanism
+        to grab OOBM interface address.
+
+        :return: The address (IP or FQDN) of the services interface (oobm).
+        :rtype: str
+        """
+        network_name = self._container_name + '_oobm'
+        address = self._client.inspect_container(
+            self.container_id
+        )['NetworkSettings']['Networks'][network_name]['IPAddress']
+        return address
+
     def notify_add_biport(self, node, biport):
         """
         Get notified that a new biport was added to this engine node.
@@ -358,25 +391,6 @@ class DockerNode(CommonNode):
             'ip link set dev {iface} {state}'.format(**locals())
         )
         self._docker_exec(command)
-
-    def _docker_exec(self, command):
-        """
-        Execute a command inside the docker.
-
-        :param str command: The command to execute.
-        """
-        log.debug(
-            '[{}]._docker_exec(\'{}\') ::'.format(self._container_id, command)
-        )
-
-        response = check_output(shsplit(
-            'docker exec {container_id} {command}'.format(
-                container_id=self._container_id, command=command.strip()
-            )
-        )).decode('utf8')
-
-        log.debug(response)
-        return response
 
 
 __all__ = ['DockerNode']

--- a/lib/topology_docker/nodes/host.py
+++ b/lib/topology_docker/nodes/host.py
@@ -39,11 +39,21 @@ class HostNode(DockerNode):
     def __init__(self, identifier, image='ubuntu:14.04', **kwargs):
 
         super(HostNode, self).__init__(identifier, image=image, **kwargs)
-        self._shells['bash'] = DockerBashShell(
-            self.container_id, 'bash'
+
+        # Create and register shells
+        self._register_shell(
+            'bash',
+            DockerBashShell(
+                self.container_id,
+                'bash'
+            )
         )
-        self._shells['bash_front_panel'] = DockerBashShell(
-            self.container_id, 'ip netns exec front_panel bash'
+        self._register_shell(
+            'bash_front_panel',
+            DockerBashShell(
+                self.container_id,
+                'ip netns exec front_panel bash'
+            )
         )
 
 

--- a/lib/topology_docker/platform.py
+++ b/lib/topology_docker/platform.py
@@ -26,8 +26,8 @@ import logging
 from traceback import format_exc
 from collections import OrderedDict
 
-from topology.platforms.base import BasePlatform
 from topology.platforms.utils import NodeLoader
+from topology.platforms.platform import BasePlatform
 
 from .node import DockerNode
 from .utils import tmp_iface, privileged_cmd
@@ -41,7 +41,7 @@ class DockerPlatform(BasePlatform):
     """
     Plugin to build a topology using Docker.
 
-    See :class:`topology.platforms.base.BasePlatform` for more information.
+    See :class:`topology.platforms.platform.BasePlatform` for more information.
     """
 
     def __init__(self, timestamp, nmlmanager):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -19,3 +19,6 @@ autoapi
 # Topology libraries
 topology_lib_ip
 topology_lib_ping
+
+# Remove when Topology 1.8 is released
+-e git+https://github.com/HPENetworking/topology.git@services_api#egg=topology

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 six
 docker-py
-topology>=1.5.0
+
+# Uncomment when topology 1.8 is released
+# topology>=1.8.0

--- a/test/test_topology_docker_platform.py
+++ b/test/test_topology_docker_platform.py
@@ -256,7 +256,7 @@ def test_unlink_relink():
     # Setup which shell to use
     shell = 'bash_front_panel'
 
-    topology = "[identifier=thelink] hs1:a -- hs2:b"
+    topology = '[identifier=thelink] hs1:a -- hs2:b'
 
     mgr = TopologyManager(engine='docker')
     mgr.parse(topology)
@@ -317,10 +317,10 @@ def test_netns_list():
 
     platform.destroy()
 
-    assert "front_panel" in result
+    assert 'front_panel' in result
 
     # Test that an another network namespace is not in the list
-    assert "\n" not in result
+    assert '\n' not in result
 
 
 def test_docker_network():
@@ -371,12 +371,10 @@ def test_lo_up():
 
     result = hs1('ip link list lo', shell='bash')
     result_front_panel = hs1('ip link list lo', shell='bash_front_panel')
-    # from pdb import set_trace
-    # set_trace()
 
     platform.destroy()
 
-    # FIXME: change to test for "UP" in result once this becomes the correct
+    # FIXME: change to test for 'UP' in result once this becomes the correct
     # operstate for lo interfaces in all supported kernels (see comment above)
-    assert "DOWN" not in result
-    assert "DOWN" not in result_front_panel
+    assert 'DOWN' not in result
+    assert 'DOWN' not in result_front_panel


### PR DESCRIPTION
Changes to support upcomming Topology 1.8: https://github.com/HPENetworking/topology/milestone/1

1) Removed imports of deprecated modules: https://github.com/HPENetworking/topology/pull/25
2) Added implementation of the Topology 1.8 _get_services_address() method on nodes: https://github.com/HPENetworking/topology/pull/27
3) Changes shell registration to use _register_shell() method. https://github.com/HPENetworking/topology/pull/27