### PR TITLE
New switch-type node

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,6 +81,46 @@ This methods allow to pause and resume a node in the topology to test failover,
 replication, balancing or for simple management.
 
 
+Node types provided by default
+==============================
+
+This Platform Engine provides two types of nodes by default: *host* and
+*switch*.
+
+Host Node Type
+++++++++++++++
+
+This is a very simple host that can be used in topologies where there is a need
+to simulate a Linux-based host system. This node is based on an Ubuntu 14.04
+image (by default) and uses bash for its shell.
+
+It provides the two default network categories (as inherited from DockerNode):
+`front_panel` and `oobm`. The first one is used for ports that are going to be
+connected to other nodes and the second one is used to connect the node to a
+bridge network managed by docker itself (which means it's not explicitly part
+of the topology).
+
+Switch Node Type
+++++++++++++++++
+
+This is a very simple switch that can be used in topologies where there is a
+need to simulate a switch that will just forward packets to the correct port
+based on the mac address that's connected to it. This node is based on an
+Ubuntu 14.04 image (by default) and uses bash for its shell.
+
+It provides the two default network categories (as inherited from DockerNode):
+`front_panel` and `oobm`. The first one is used for ports that are going to be
+connected to other nodes and the second one is used to connect the switch to a
+bridge network managed by docker itself (which means it's not explicitly part
+of the topology).
+
+All the ports in this node type (except the implicit one in the `oobm`
+category) are added to a kernel-level bridge named `bridge0` which provides
+the switching functionality. Because of the way this type of bridges work, all
+interfaces added to it must be set to UP state, which means ports in nodes of
+this type will ignore the UP element attribute referenced above (all ports will
+be brought UP regardless of it).
+
 Development
 ===========
 

--- a/examples/switch.szn
+++ b/examples/switch.szn
@@ -1,0 +1,19 @@
+
+# +-------+                     +-------+
+# |       |     +---------+     |       |
+# |  hs1  <----->   sw1   <----->  hs2  |
+# |       |     +---------+     |       |
+# +-------+                     +-------+
+
+# Nodes
+[type=host name="Host 1"] hs1
+[type=host name="Host 2"] hs2
+[type=switch name="Switch 1"] sw1
+
+# Ports
+[ipv4="192.168.20.20/24" up="True"]hs1:1
+[ipv4="192.168.20.21/24" up="True"]hs2:1
+
+# Links
+hs1:1 -- sw1:1
+hs2:1 -- sw1:2

--- a/lib/topology_docker/nodes/switch.py
+++ b/lib/topology_docker/nodes/switch.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Simple switch Topology Docker Node using Ubuntu.
+"""
+
+from __future__ import unicode_literals, absolute_import
+from __future__ import print_function, division
+
+from topology_docker.node import DockerNode
+from topology_docker.shell import DockerBashShell
+
+
+class SwitchNode(DockerNode):
+    """
+    Simple switch node for the Topology Docker platform engine.
+
+    This base switch loads an ubuntu image (by default) and creates a
+    kernel-level bridge where it adds all of its front-panel interfaces to
+    emulate the behaviour of a real "dumb" switch.
+
+    See :class:`topology_docker.node.DockerNode`.
+    """
+
+    def __init__(self, identifier, image='ubuntu:14.04', **kwargs):
+
+        super(SwitchNode, self).__init__(identifier, image=image, **kwargs)
+
+        # Create and register shells
+        self._register_shell(
+            'bash',
+            DockerBashShell(
+                self.container_id,
+                'bash'
+            )
+        )
+        self._register_shell(
+            'bash_front_panel',
+            DockerBashShell(
+                self.container_id,
+                'ip netns exec front_panel bash'
+            )
+        )
+
+    def notify_post_build(self):
+        """
+        Get notified that the post build stage of the topology build was
+        reached.
+
+        See :meth:`DockerNode.notify_post_build` for more information.
+        """
+        super(SwitchNode, self).notify_post_build()
+
+        # Let's create the bridge interface and then bring it up
+        netns_exec = 'ip netns exec front_panel'
+        self._docker_exec(
+            '{} ip link add name bridge0 type bridge'.format(netns_exec)
+        )
+        self._docker_exec(
+            '{} ip link set bridge0 up'.format(netns_exec)
+        )
+
+        # Get the ports created by the framework
+        created_ports = list(self.ports.keys())
+
+        # Add the ports to the bridge (for this they need to be UP first)
+        for port in created_ports:
+            self._docker_exec('{} ip link set {} up'.format(netns_exec, port))
+            self._docker_exec('{} ip link set {} master bridge0'.format(
+                netns_exec,
+                port
+            ))
+
+
+__all__ = ['SwitchNode']

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -21,4 +21,4 @@ topology_lib_ip
 topology_lib_ping
 
 # Remove when Topology 1.8 is released
--e git+https://github.com/HPENetworking/topology.git@services_api#egg=topology
+-e git+https://github.com/HPENetworking/topology.git@e4a509bbe8b9523c20483e07f7a3eb4677970c6c#egg=topology

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         ],
         'topology_docker_node_10': [
             'host = topology_docker.nodes.host:HostNode',
+            'switch = topology_docker.nodes.switch:SwitchNode',
         ]
     }
 )

--- a/test/test_topology_docker_nodes_switch.py
+++ b/test/test_topology_docker_nodes_switch.py
@@ -56,9 +56,14 @@ def test_ping(topology, step):
     assert ping_hs2_to_hs1['transmitted'] == ping_hs2_to_hs1['received'] == 1
 
     # Should not work, host 3 is not in the same subnet as the other 2 hosts
-    no_ping = hs3.libs.ping.ping(1, '192.168.15.1')
-    assert no_ping['transmitted'] == 1
-    assert no_ping['received'] == 0
+    # We should implement this with ping's communication library once the
+    # "network unreachable" scenario is supported by uncommenting the following
+    # three lines
+    # no_ping = hs3.libs.ping.ping(1, '192.168.15.1', shell=shell)
+    # assert no_ping['transmitted'] == 1
+    # assert no_ping['received'] == 0
+    no_ping = hs3('ping -c 1 192.168.15.1', shell=shell)
+    assert 'Network is unreachable' in no_ping
 
     # Should not work, not node exists with that ip
     no_ping = hs2.libs.ping.ping(1, '192.168.15.3')

--- a/test/test_topology_docker_nodes_switch.py
+++ b/test/test_topology_docker_nodes_switch.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for switch.
+"""
+
+from __future__ import unicode_literals, absolute_import
+from __future__ import print_function, division
+
+TOPOLOGY = """
+[type=host name="Host 1"] hs1
+[type=host name="Host 2"] hs2
+[type=host name="Host 3"] hs3
+[type=switch name="Switch 1"] sw1
+
+[ipv4="192.168.15.1/24" up=True] hs1:1
+[ipv4="192.168.15.2/24" up=True] hs2:1
+[ipv4="192.168.16.3/24" up=True] hs3:1
+
+hs1:1 -- sw1:p1
+hs2:1 -- sw1:p2
+hs3:1 -- sw1:p3
+"""
+
+
+def test_ping(topology, step):
+    """
+    Test that two nodes can ping each other through the switch.
+    """
+    # Setup which shell to use
+    shell = 'bash_front_panel'
+
+    hs1 = topology.get('hs1')
+    hs2 = topology.get('hs2')
+    hs3 = topology.get('hs3')
+
+    ping_hs1_to_hs2 = hs1.libs.ping.ping(1, '192.168.15.2', shell=shell)
+    ping_hs2_to_hs1 = hs2.libs.ping.ping(1, '192.168.15.1', shell=shell)
+
+    assert ping_hs1_to_hs2['transmitted'] == ping_hs1_to_hs2['received'] == 1
+    assert ping_hs2_to_hs1['transmitted'] == ping_hs2_to_hs1['received'] == 1
+
+    # Should not work, host 3 is not in the same subnet as the other 2 hosts
+    no_ping = hs3.libs.ping.ping(1, '192.168.15.1')
+    assert no_ping['transmitted'] == 1
+    assert no_ping['received'] == 0
+
+    # Should not work, not node exists with that ip
+    no_ping = hs2.libs.ping.ping(1, '192.168.15.3')
+    assert no_ping['transmitted'] == 1
+    assert no_ping['received'] == 0


### PR DESCRIPTION
This new node type will provide a missing building block that will allow the most basic topologies to be built without requiring any external repository (for topology setup testing purposes, a quick start guide, etc.), plus it helps when you need a simple switch for a topology but that switch is not a part of the system under test (so it should be really simple and stable).

This should be production ready right now, the only thing that could be an issue is that an interface needs to be UP to be added to a linux software bridge, which means we are setting the ports to this state irrespective of what our users set them to in the SZN spec.