### PR TITLE
fix: usr: Fixed crash when docker-py returns None for the tags of an image.

### DIFF
--- a/lib/topology_docker/node.py
+++ b/lib/topology_docker/node.py
@@ -213,7 +213,8 @@ class DockerNode(CommonNode):
         """
         # Search for image in available images
         for tags in [img['RepoTags'] for img in self._client.images()]:
-            if self._image in tags:
+            # Docker py can return repo tags as None
+            if tags and self._image in tags:
                 return
 
         # Determine image parts


### PR DESCRIPTION
This fixes issue #47 .