### PR TITLE
fix: dev: Setting proper bash default shell for hosts.

### DIFF
--- a/lib/topology_docker/nodes/host.py
+++ b/lib/topology_docker/nodes/host.py
@@ -45,14 +45,14 @@ class HostNode(DockerNode):
             'bash',
             DockerBashShell(
                 self.container_id,
-                'bash'
+                'ip netns exec front_panel bash'
             )
         )
         self._register_shell(
-            'bash_front_panel',
+            'bash_oobm',
             DockerBashShell(
                 self.container_id,
-                'ip netns exec front_panel bash'
+                'bash'
             )
         )
 


### PR DESCRIPTION
I think this *should* put a band-aid to fix the issue #45. @jeffesquivels suggested a smarter approach that sets the default shell depending on the value of the ``default_category`` set for the particular node. @carlos-jenkins, comments on this?

Please do not merge until you have posted your opinion on this pull request.