### PR TITLE
fix: dev: Fix private-reg docker pull issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 six
-docker-py==1.9.0
+docker-py==1.10.4
 topology>=1.8.0


### PR DESCRIPTION
Upgrading the docker-py version to 1.10.4 seems
to fix the issue where it failed to pull
images from private registries.

Closes #54