### PR TITLE
Fix container name in topology subnodes

### DIFF
--- a/lib/topology_docker/__init__.py
+++ b/lib/topology_docker/__init__.py
@@ -21,4 +21,4 @@ topology_docker module entry point.
 
 __author__ = 'Hewlett Packard Enterprise Development LP'
 __email__ = 'hpe-networking@lists.hp.com'
-__version__ = '1.8.1'
+__version__ = '1.8.2'

--- a/lib/topology_docker/node.py
+++ b/lib/topology_docker/node.py
@@ -128,7 +128,7 @@ class DockerNode(CommonNode):
         self._client = APIClient(version='auto')
 
         self._container_name = '{identifier}_{pid}_{timestamp}'.format(
-            identifier=identifier, pid=getpid(),
+            identifier=identifier.replace('>', '.'), pid=getpid(),
             timestamp=datetime.now().isoformat().replace(':', '-')
         )
         self._shared_dir_base = shared_dir_base


### PR DESCRIPTION
With topology 1.18+ now topologies support subnodes of the form node>subnode. This commit fixes an error caused by subnodes having '>' on its name:

```
docker.errors.APIError: ...
Bad Request ("Invalid container name
(eri1>part_248403_2025-03-31T14-54-02.724975),
only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed")
```